### PR TITLE
Fix not unique table/alias

### DIFF
--- a/src/VersioningScope.php
+++ b/src/VersioningScope.php
@@ -34,25 +34,6 @@ class VersioningScope implements Scope
     }
 
     /**
-     * Remove the scope from the given Eloquent query builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    public function remove(Builder $builder, Model $model)
-    {
-        $table = $model->getVersionTable();
-
-        $query = $builder->getQuery();
-
-        $query->joins = collect($query->joins)->reject(function($join) use ($table)
-        {
-            return $this->isVersionJoinConstraint($join, $table);
-        })->values()->all();
-    }
-
-    /**
      * Extend the query builder with the needed functions.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
@@ -77,9 +58,7 @@ class VersioningScope implements Scope
         $builder->macro('version', function(Builder $builder, $version) {
             $model = $builder->getModel();
 
-            $this->remove($builder, $builder->getModel());
-
-            $builder->join($model->getVersionTable(), function($join) use ($model, $version) {
+            $builder->withoutGlobalScope($this)->join($model->getVersionTable(), function($join) use ($model, $version) {
                 $join->on($model->getQualifiedKeyName(), '=', $model->getQualifiedVersionKeyName());
                 $join->where($model->getQualifiedVersionColumn(), '=', $version);
             });
@@ -99,26 +78,12 @@ class VersioningScope implements Scope
         $builder->macro('allVersions', function(Builder $builder) {
             $model = $builder->getModel();
 
-            $this->remove($builder, $builder->getModel());
-
-            $builder->join($model->getVersionTable(), function($join) use ($model) {
+            $builder->withoutGlobalScope($this)->join($model->getVersionTable(), function($join) use ($model) {
                 $join->on($model->getQualifiedKeyName(), '=', $model->getQualifiedVersionKeyName());
             });
 
             return $builder;
         });
-    }
-
-    /**
-     * Determine if the given join clause is a version constraint.
-     *
-     * @param  \Illuminate\Database\Query\JoinClause   $join
-     * @param  string  $column
-     * @return bool
-     */
-    protected function isVersionJoinConstraint(JoinClause $join, $table)
-    {
-        return $join->type == 'inner' && $join->table == $table;
     }
 
 }


### PR DESCRIPTION
I noticed I had the same issue as #4. Started looking around and noticed that Eloquent's own [SoftDeletingScope](https://github.com/illuminate/database/blob/master/Eloquent/SoftDeletingScope.php#L133) uses `$builder->withoutGlobalScope($this)->` to ignore inheriting of itself on the extensions. That is what I did here. Seems to be working as expected for me.