### PR TITLE
Delete wasn't removing versioned rows

### DIFF
--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -159,7 +159,7 @@ trait BuilderTrait
     public function forceDelete()
     {
         // get records
-        $affectedRecords = $this->getAffectedRecords();
+        $affectedRecords = $this->getAffectedRecords()->toArray();
         $ids = array_map(function($record) {
             return $record->{$this->model->getKeyName()};
         }, $affectedRecords);


### PR DESCRIPTION
Delete wasn't removing versioned rows. `array_map` expects second parameter to be an array not an object which `$this->getAffectedRecords()` returns.