### PR TITLE
Fix update method.

### DIFF
--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -116,17 +116,21 @@ trait BuilderTrait
         // update version table records
         $db = $this->model->getConnection();
         foreach ($affectedRecords as $record) {
-            // get versioned values from record
-            foreach($this->model->getVersionedAttributeNames() as $key) {
-                $recordVersionValues[$key] = (isset($versionValues[$key])) ? $versionValues[$key] : $record->{$key};
-            }
+            // get current version values
+            $currentVersionValues = $db->table($this->model->getVersionTable())
+                ->where([
+                    [$this->model->getVersionKeyName(), $record->{$this->model->getKeyName()}],
+                    [$this->model->getVersionColumn(), $record->{$this->model->getLatestVersionColumn()}]
+                ])->first();
 
-            // merge versioned values from record and input
-            $recordVersionValues = array_merge($recordVersionValues, $versionValues);
+            // merge current version with updated values to create new version
+            foreach($this->model->getVersionedAttributeNames() as $key) {
+                $recordVersionValues[$key] = (isset($versionValues[$key])) ? $versionValues[$key] : $currentVersionValues->{$key};
+            }
 
             // set version and ref_id
             $recordVersionValues[$this->model->getVersionKeyName()] = $record->{$this->model->getKeyName()};
-            $recordVersionValues[$this->model->getVersionColumn()] = $record->{$this->model->getVersionColumn()}+1;
+            $recordVersionValues[$this->model->getVersionColumn()] = $record->{$this->model->getLatestVersionColumn()}+1;
 
             // insert new version
             if(! $db->table($this->model->getVersionTable())->insert($recordVersionValues)) {


### PR DESCRIPTION
I noticed my update method wasn't working either. It was updating the main table, but erroring out on the versioned table. Using a duplicate key of 1 for every update no matter how many versions. Looks like `getVersionColumn()` needed to be changed to `getLatestVersionColumn()`.

I also added code that fetches the old version row and merges in the new updates. The way the old code was wrote it would only insert a versioned row with just the updated values, and `null` out the existing data. I believe this was the desired behavior.