### PR TITLE
Avoid saving casts to DB

### DIFF
--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -122,7 +122,7 @@ trait BuilderTrait
         foreach ($affectedRecords as $record) {
             // get versioned values from record
             foreach($this->model->getVersionedAttributeNames() as $key) {
-                $recordVersionValues[$key] = (isset($versionValues[$key])) ? $versionValues[$key] : $record->{$key};
+                $recordVersionValues[$key] = (isset($versionValues[$key])) ? $versionValues[$key] : array_get($record->getAttributes(), $key);
             }
 
             // merge versioned values from record and input


### PR DESCRIPTION
When adding a versioned attribute that also has a accessor or cast of some kind, the current code retrieves the _accessor_/_casted_ version and attempts to store that, instead of the _mutated_ DB-friendly version we would expect. This commit fixes that, by retrieving the value from the raw attributes array, instead of through the virtual property, and thereby skips any accessors/casts.

This issue came up while using this package along with Spatie's translatable models package, and MySQL throwing a fit about not wanting to save the non-JSON'd English translation of a value in a JSON field. This change fixes that issue, and probably many others besides.